### PR TITLE
Remove duplicate 'Architecture Topics' listings in Sphinx docs

### DIFF
--- a/doc/source/architecture/dependencies.md
+++ b/doc/source/architecture/dependencies.md
@@ -12,10 +12,6 @@
 - Understand JavaScript dependency management
 - Learn about the wheels server
 
-## Dependencies
-
-
-
 ## Dependencies - Python
 
 `script/common_startup.sh` sets up a `virtualenv` with required dependencies in `$GALAXY_ROOT/.venv` (or `$GALAXY_VIRTUAL_ENV` if set).

--- a/doc/source/architecture/index.md
+++ b/doc/source/architecture/index.md
@@ -4,6 +4,7 @@ Core documentation about Galaxy's internal architecture and design.
 
 ```{toctree}
 :maxdepth: 1
+:caption: Architecture Topics
 
 ecosystem
 project-management
@@ -19,21 +20,3 @@ dependencies
 startup
 production
 ```
-
-## Available Topics
-
-This section documents Galaxy's key architectural patterns:
-
-- **[Galaxy Ecosystem and Projects](ecosystem.md)**
-- **[Galaxy Project Management and Contribution](project-management.md)**
-- **[Galaxy Architecture Principles](principles.md)**
-- **[Galaxy Files and Directory Structure](files.md)**
-- **[Galaxy Web Frameworks](frameworks.md)**
-- **[Dependency Injection in Galaxy](dependency-injection.md)**
-- **[Galaxy Task Management with Celery](tasks.md)**
-- **[Galaxy Application Components: Models, Managers, and Services](application-components.md)**
-- **[Galaxy Plugin Architecture](plugins.md)**
-- **[Galaxy Client Architecture](client.md)**
-- **[Galaxy Dependencies Management](dependencies.md)**
-- **[Galaxy Startup Process](startup.md)**
-- **[Galaxy Production Deployment](production.md)**

--- a/doc/source/architecture/production.md
+++ b/doc/source/architecture/production.md
@@ -13,10 +13,6 @@
 - Understand multi-process and multi-host setups
 - Learn about usegalaxy.org infrastructure
 
-## Production Galaxy - usegalaxy.org
-
-
-
 #### Default
 
 SQLite

--- a/doc/source/architecture/startup.md
+++ b/doc/source/architecture/startup.md
@@ -13,10 +13,6 @@
 - Understand dependency installation
 - Learn about database migrations and plugin loading
 
-## Galaxy Startup Process
-
-
-
 ## Cloning Galaxy
 
 ```bash

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -4,7 +4,6 @@ This section documents Galaxy's internal architecture and design patterns.
 
 ```{toctree}
 :maxdepth: 2
-:caption: Architecture Topics
 
 architecture/index
 ```

--- a/outputs/sphinx-docs/build.py
+++ b/outputs/sphinx-docs/build.py
@@ -485,21 +485,11 @@ Core documentation about Galaxy's internal architecture and design.
 
 ```{{toctree}}
 :maxdepth: 1
+:caption: Architecture Topics
 
 {toctree_items}
 ```
-
-## Available Topics
-
-This section documents Galaxy's key architectural patterns:
-
 """
-
-    # Add links for each topic in order
-    for topic_id in ordered_topics:
-        if topic_id in topic_metadata:
-            metadata = topic_metadata[topic_id]
-            content += f"- **[{metadata.title}]({topic_id}.md)**\n"
 
     index_file.write_text(content)
     print(f"✓ Updated: {index_file}")


### PR DESCRIPTION
- Remove 'Available Topics' section from architecture/index.md generation
- Use toctree with caption instead of manual topic list
- Simplify index.md sidebar hierarchy to avoid duplication
- toctree now serves as single source of truth for topic navigation