### PR TITLE
Document async/sync event-loop pitfall + generate review command (#19)

### DIFF
--- a/doc/source/architecture/frameworks.md
+++ b/doc/source/architecture/frameworks.md
@@ -12,6 +12,7 @@
 - Learn about ASGI, Starlette, and FastAPI
 - Understand WSGI and legacy routing
 - Learn about middleware layers
+- Avoid blocking the ASGI event loop from async handlers
 
 ![Client-Server Communications](../_images/server_client_vuejs.plantuml.svg)
 
@@ -474,6 +475,69 @@ class FastAPIRoles:
         return role_to_model(trans, role)
 ```
 
+## Pitfall: `async def` Doing Blocking I/O
+
+Spotted in review of `galaxyproject/galaxy#22361`:
+
+```python
+async def list_history_items(session: Session, history_id: int) -> str:
+    hda_rows = session.execute(
+        select(HDA.id, HDA.hid, HDA.name)
+        .join(Dataset, HDA.dataset_id == Dataset.id)
+        .where(HDA.history_id == history_id)
+    ).all()
+    ...
+```
+
+Declared `async`, but `session` is a **synchronous** SQLAlchemy `Session` —
+`session.execute(...)` is a blocking call.
+
+## Why This Breaks Galaxy
+
+- Galaxy serves FastAPI on a single ASGI event loop (uvicorn).
+- `async def` runs *on* the loop; sync `def` runs in a threadpool.
+- A blocking call inside `async def` freezes the loop — stalling *every*
+  concurrent request on that worker, not just the caller.
+- Galaxy's `Session` is synchronous, so `session.execute(...)` blocks.
+
+> "This is a must before merging, this would block the event loop."
+> — review of `galaxyproject/galaxy#22361`
+
+## Convention: Default to Sync `def`
+
+```diff
+-async def list_history_items(session: Session, history_id: int) -> str:
++def list_history_items(session: Session, history_id: int) -> str:
+     rows = session.execute(select(...)).all()
+```
+
+- DB-bound service/handler code: plain `def` — FastAPI runs it in a threadpool.
+- Use `async def` *only* for genuine async I/O (httpx, websockets, anyio).
+- Must call blocking code from `async`? Offload it:
+
+```python
+rows = await anyio.to_thread.run_sync(partial(list_history_items, session, history_id))
+```
+
+## The Guard Only Catches Tested Code
+
+Galaxy ships an `aiocop` integration
+(`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
+`GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
+catch blocking syscalls made from inside async tasks. Violations are surfaced
+on an `X-Aiocop-Violations` response header so the test harness can fail
+requests that block the event loop (see
+`test/integration/test_event_loop_blocking.py`).
+
+The reviewer's question on `galaxyproject/galaxy#22361` — *"Our aiocop
+integration should have flagged this, is this executed in our test suite?"* —
+is the real lesson. The audit hook only fires on code paths actually
+exercised under tests with aiocop enabled. An `async def` helper with no
+integration coverage slips straight through the guard. So new async
+endpoints and helpers need test coverage that exercises them, and code
+review must check the declaration intent directly — whether a coroutine
+genuinely does async I/O — rather than trusting the guard to catch it.
+
 ## FastAPI and Pydantic
 
 ```python
@@ -568,3 +632,4 @@ class RoleAPIController(BaseGalaxyAPIController):
 - Middleware handles cross-cutting concerns
 - Routing maps URLs to controllers
 - Three types of controllers: FastAPI, WSGI API, legacy web
+- `async def` must not do blocking sync I/O — default to sync `def`

--- a/doc/source/architecture/frameworks.md
+++ b/doc/source/architecture/frameworks.md
@@ -500,8 +500,6 @@ Declared `async`, but `session` is a **synchronous** SQLAlchemy `Session` —
 - A blocking call inside `async def` stalls *every* concurrent request — not just the caller.
 - Sync `def` is dispatched to a threadpool, leaving the loop free.
 
-> A blocking call in an `async def` is an event-loop hazard — fix it, don't merge it.
-
 ## Convention: Default to Sync `def`
 
 ```diff

--- a/doc/source/architecture/frameworks.md
+++ b/doc/source/architecture/frameworks.md
@@ -492,13 +492,13 @@ async def list_history_items(session: Session, history_id: int) -> str:
 Declared `async`, but `session` is a **synchronous** SQLAlchemy `Session` —
 `session.execute(...)` is a blocking call.
 
+![Event Loop Blocking vs Threadpool](../_images/event_loop_blocking.mermaid.svg)
+
 ## Why This Breaks Galaxy
 
-- Galaxy serves FastAPI on a single ASGI event loop (uvicorn).
-- `async def` runs *on* the loop; sync `def` runs in a threadpool.
-- A blocking call inside `async def` freezes the loop — stalling *every*
-  concurrent request on that worker, not just the caller.
-- Galaxy's `Session` is synchronous, so `session.execute(...)` blocks.
+- One ASGI event loop per worker; `async def` runs *on* it.
+- A blocking call inside `async def` stalls *every* concurrent request — not just the caller.
+- Sync `def` is dispatched to a threadpool, leaving the loop free.
 
 > A blocking call in an `async def` is an event-loop hazard — fix it, don't merge it.
 
@@ -519,32 +519,40 @@ Declared `async`, but `session` is a **synchronous** SQLAlchemy `Session` —
 rows = await anyio.to_thread.run_sync(partial(list_history_items, session, history_id))
 ```
 
-## The Guard Only Catches Tested Code
+## The aiocop Guard
 
-Galaxy ships an `aiocop` integration
-(`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
-`GALAXY_TEST_AIOCOP` environment variable). aiocop installs `sys.audit`
-hooks that catch specific blocking syscalls — `socket.connect`, `open`,
-`subprocess.Popen`, and similar — when they run inside an async task, and
-records the offending call site. Galaxy wraps this in an ASGI middleware
-that attaches any per-request violations to an `X-Aiocop-Violations`
-response header (`count=…;severity=…;first=…`); the API test interactor
-fails any request whose maximum severity reaches aiocop's high threshold
-(see `test/integration/test_event_loop_blocking.py` and
-`galaxy_test.base.api._check_aiocop_violations`). It is a test-only
-dependency — not imported by production servers.
+Opt-in via `GALAXY_TEST_AIOCOP=1` — `sys.audit` hooks catch blocking
+syscalls inside async tasks and tag the response with
+`X-Aiocop-Violations`; the test interactor fails any high-severity hit.
+
+- Runtime audit hook, **not** a static check.
+- Only sees code paths a test actually executes.
+- Untested `async def` slips through — declaration intent is on review.
+
+`lib/galaxy/web/framework/middleware/aiocop_integration.py` ·
+`test/integration/test_event_loop_blocking.py`
+
+Galaxy's `aiocop` integration
+(`lib/galaxy/web/framework/middleware/aiocop_integration.py`) installs
+`sys.audit` hooks that catch specific blocking syscalls — `socket.connect`,
+`open`, `subprocess.Popen`, and similar — when they run inside an async
+task, and records the offending call site. Galaxy wraps this in an ASGI
+middleware that attaches any per-request violations to an
+`X-Aiocop-Violations` response header
+(`count=…;severity=…;first=…`); the API test interactor
+(`galaxy_test.base.api._check_aiocop_violations`) fails any request whose
+maximum severity reaches aiocop's high threshold. It is a test-only
+dependency, opt-in via `GALAXY_TEST_AIOCOP`, and is not imported by
+production servers.
 
 The limitation that matters: aiocop is a *runtime* audit hook, not a static
 check. It only observes a blocking call on a code path that is actually
-executed while aiocop is active — i.e. under the integration suite with
-`GALAXY_TEST_AIOCOP` set. An `async def` that does synchronous I/O but is
-never exercised by such a test slips straight through; so does one whose
-blocking call stays below the severity threshold. The guard is a safety net
-for covered paths, not a substitute for getting the declaration right.
-Treat sync-vs-async correctness as a code-review responsibility — check
-whether a coroutine genuinely awaits async I/O — and give new async
-endpoints and helpers integration coverage that runs them so the guard can
-see them.
+executed while aiocop is active. An `async def` that does synchronous I/O
+but is never exercised by such a test slips straight through; so does one
+whose blocking call stays below the severity threshold. The guard is a
+safety net for covered paths, not a substitute for getting the declaration
+right — treat sync-vs-async correctness as a code-review responsibility and
+give new async endpoints integration coverage that runs them.
 
 ## FastAPI and Pydantic
 

--- a/doc/source/architecture/frameworks.md
+++ b/doc/source/architecture/frameworks.md
@@ -530,6 +530,8 @@ syscalls inside async tasks and tag the response with
 `lib/galaxy/web/framework/middleware/aiocop_integration.py` ·
 `test/integration/test_event_loop_blocking.py`
 
+[https://github.com/galaxyproject/galaxy/pull/22207](https://github.com/galaxyproject/galaxy/pull/22207)
+
 Galaxy's `aiocop` integration
 (`lib/galaxy/web/framework/middleware/aiocop_integration.py`) installs
 `sys.audit` hooks that catch specific blocking syscalls — `socket.connect`,

--- a/doc/source/architecture/frameworks.md
+++ b/doc/source/architecture/frameworks.md
@@ -512,6 +512,7 @@ Declared `async`, but `session` is a **synchronous** SQLAlchemy `Session` —
 
 - DB-bound service/handler code: plain `def` — FastAPI runs it in a threadpool.
 - Use `async def` *only* for genuine async I/O (httpx, websockets, anyio).
+- Exercise every new async path with an API/integration test — untested async I/O is unverified.
 - Must call blocking code from `async`? Offload it:
 
 ```python
@@ -640,3 +641,4 @@ class RoleAPIController(BaseGalaxyAPIController):
 - Routing maps URLs to controllers
 - Three types of controllers: FastAPI, WSGI API, legacy web
 - `async def` must not do blocking sync I/O — default to sync `def`
+- Exercise new async code paths with API/integration tests — untested async I/O is unverified

--- a/doc/source/architecture/frameworks.md
+++ b/doc/source/architecture/frameworks.md
@@ -477,7 +477,7 @@ class FastAPIRoles:
 
 ## Pitfall: `async def` Doing Blocking I/O
 
-Spotted in review of `galaxyproject/galaxy#22361`:
+A common mistake — a helper declared `async` that only does blocking work:
 
 ```python
 async def list_history_items(session: Session, history_id: int) -> str:
@@ -500,8 +500,7 @@ Declared `async`, but `session` is a **synchronous** SQLAlchemy `Session` —
   concurrent request on that worker, not just the caller.
 - Galaxy's `Session` is synchronous, so `session.execute(...)` blocks.
 
-> "This is a must before merging, this would block the event loop."
-> — review of `galaxyproject/galaxy#22361`
+> A blocking call in an `async def` is an event-loop hazard — fix it, don't merge it.
 
 ## Convention: Default to Sync `def`
 
@@ -523,20 +522,28 @@ rows = await anyio.to_thread.run_sync(partial(list_history_items, session, histo
 
 Galaxy ships an `aiocop` integration
 (`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
-`GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
-catch blocking syscalls made from inside async tasks. Violations are surfaced
-on an `X-Aiocop-Violations` response header so the test harness can fail
-requests that block the event loop (see
-`test/integration/test_event_loop_blocking.py`).
+`GALAXY_TEST_AIOCOP` environment variable). aiocop installs `sys.audit`
+hooks that catch specific blocking syscalls — `socket.connect`, `open`,
+`subprocess.Popen`, and similar — when they run inside an async task, and
+records the offending call site. Galaxy wraps this in an ASGI middleware
+that attaches any per-request violations to an `X-Aiocop-Violations`
+response header (`count=…;severity=…;first=…`); the API test interactor
+fails any request whose maximum severity reaches aiocop's high threshold
+(see `test/integration/test_event_loop_blocking.py` and
+`galaxy_test.base.api._check_aiocop_violations`). It is a test-only
+dependency — not imported by production servers.
 
-The reviewer's question on `galaxyproject/galaxy#22361` — *"Our aiocop
-integration should have flagged this, is this executed in our test suite?"* —
-is the real lesson. The audit hook only fires on code paths actually
-exercised under tests with aiocop enabled. An `async def` helper with no
-integration coverage slips straight through the guard. So new async
-endpoints and helpers need test coverage that exercises them, and code
-review must check the declaration intent directly — whether a coroutine
-genuinely does async I/O — rather than trusting the guard to catch it.
+The limitation that matters: aiocop is a *runtime* audit hook, not a static
+check. It only observes a blocking call on a code path that is actually
+executed while aiocop is active — i.e. under the integration suite with
+`GALAXY_TEST_AIOCOP` set. An `async def` that does synchronous I/O but is
+never exercised by such a test slips straight through; so does one whose
+blocking call stays below the severity threshold. The guard is a safety net
+for covered paths, not a substitute for getting the declaration right.
+Treat sync-vs-async correctness as a code-review responsibility — check
+whether a coroutine genuinely awaits async I/O — and give new async
+endpoints and helpers integration coverage that runs them so the guard can
+see them.
 
 ## FastAPI and Pydantic
 

--- a/generated_agentic_operations/commands/frameworks-review-async-sync.md
+++ b/generated_agentic_operations/commands/frameworks-review-async-sync.md
@@ -1,0 +1,147 @@
+# Review Galaxy Code for Async/Sync Event-Loop Safety
+
+Perform a Python code review on the provided Galaxy code. Accept input in any of the following forms:
+1. A working directory path (analyze git diff in that directory)
+2. A Git commit reference (analyze changes in that commit)
+3. A PR reference (analyze changes in that pull request)
+4. A list of Python file paths (analyze those files)
+5. A planning document (analyze the Python files in the plan)
+
+## Who You Are
+
+- You are an expert in Python asyncio and ASGI (Starlette / FastAPI / uvicorn).
+- You know Galaxy serves FastAPI on a single ASGI event loop, and that Galaxy's
+  SQLAlchemy `Session` is **synchronous**.
+- You are a senior engineer who cares that one slow request must not stall every
+  other concurrent user on a worker.
+
+## Why This Matters
+
+Galaxy serves FastAPI on a single ASGI event loop (uvicorn). A function declared
+`async def` runs *on* that loop; a synchronous `def` endpoint/dependency is run
+by Starlette in a threadpool instead. A blocking call inside an `async def`
+therefore freezes the entire event loop — stalling **every** concurrent request
+on that worker, not just the caller.
+
+Galaxy's database layer uses a synchronous `sqlalchemy.orm.Session`, so
+`session.execute(...)`, `session.scalars(...)`, `.all()`,
+`.scalar_one_or_none()`, and lazy ORM attribute/relationship access are all
+blocking calls. Doing any of them from an `async def` without offloading is an
+event-loop hazard.
+
+Real example surfaced in review of `galaxyproject/galaxy#22361`:
+
+```python
+# ANTI-PATTERN: async, but session is a sync Session — this blocks the loop
+async def list_history_items(session: Session, history_id: int) -> str:
+    hda_rows = session.execute(
+        select(HDA.id, HDA.hid, HDA.name)
+        .join(Dataset, HDA.dataset_id == Dataset.id)
+        .where(HDA.history_id == history_id)
+    ).all()
+    ...
+```
+
+Reviewer verdict: *"This is a must before merging, this would block the event loop."*
+
+## Review Criteria
+
+Flag and recommend fixes for:
+
+1. **`async def` doing sync DB work** — sync `Session` queries (`execute`,
+   `scalars`, `.all()`, `.scalar_one_or_none()`), or lazy ORM
+   attribute/relationship access that triggers a query, inside a coroutine.
+2. **`async def` calling blocking managers/services** — invoking Galaxy
+   managers/services that do sync DB or filesystem I/O without
+   `anyio.to_thread.run_sync` / `run_in_threadpool`.
+3. **`async def` doing blocking filesystem/subprocess/HTTP** — `open(...)`,
+   `os.stat`, `shutil`, `subprocess.run`, `requests`/`urllib` instead of async
+   equivalents.
+4. **`async def` that never `await`s** — a strong signal it should be `def`.
+5. **Untested async paths** — new `async def` endpoints/helpers with no
+   integration test exercising them under `GALAXY_TEST_AIOCOP`. The guard cannot
+   catch code paths that tests never run.
+
+## Decision Tree
+
+- Does the function perform genuine async I/O (httpx, websockets, anyio,
+  `AsyncSession`)? → `async def` is appropriate.
+- Does it touch the sync `Session` or other blocking I/O and run as a FastAPI
+  endpoint/dependency? → make it plain `def`; FastAPI runs it in a threadpool.
+- Must blocking code be invoked from an existing `async def`? → offload it:
+  `await anyio.to_thread.run_sync(partial(fn, *args))`.
+
+## Fix Recipes
+
+**Preferred — drop `async`, let FastAPI's threadpool handle it** (best for
+DB-bound work; matches existing sync `def` controllers, e.g.
+`lib/galaxy/webapps/galaxy/controllers/api/roles.py`):
+
+```diff
+-async def list_history_items(session: Session, history_id: int) -> str:
++def list_history_items(session: Session, history_id: int) -> str:
+     rows = session.execute(select(...)).all()
+```
+
+**Offload at the call site** when the caller must stay `async` (pattern already
+used in `lib/galaxy/webapps/galaxy/api/chat.py`):
+
+```python
+from functools import partial
+import anyio
+
+rows = await anyio.to_thread.run_sync(partial(list_history_items, session, history_id))
+```
+
+**True async adapter / `AsyncSession`** — only when the surrounding stack is
+genuinely async. Rare in Galaxy; do not introduce it casually.
+
+## The aiocop Guard (and Its Limit)
+
+Galaxy ships an `aiocop` integration
+(`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
+`GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
+catch blocking syscalls from inside async tasks and surfaces them on an
+`X-Aiocop-Violations` response header so the harness can fail offending requests
+(see `test/integration/test_event_loop_blocking.py`).
+
+The guard only fires on code paths actually exercised under tests with aiocop
+enabled. An `async def` helper with no integration coverage slips straight
+through. Therefore: review the declaration intent directly — do not assume the
+guard will catch it — and check that new async code has tests that run it.
+
+## Related Code Paths
+
+- `lib/galaxy/web/framework/middleware/aiocop_integration.py` — the guard.
+- `test/integration/test_event_loop_blocking.py` — how the guard is exercised.
+- `lib/galaxy/webapps/galaxy/api/chat.py` — correct `anyio.to_thread.run_sync` usage.
+- `lib/galaxy/webapps/galaxy/controllers/api/roles.py` — sync `def` controllers (the norm).
+
+## Review Checklist
+
+For each file/change, check:
+
+- [ ] **No sync DB in coroutines** — `async def` bodies don't call sync
+      `Session` queries or trigger lazy ORM loads.
+- [ ] **No blocking I/O in coroutines** — no `open`/`os`/`shutil`/`subprocess`/
+      `requests` in `async def` without offload.
+- [ ] **`async` is justified** — every `async def` actually `await`s real async I/O.
+- [ ] **Offload used correctly** — blocking calls from `async` use
+      `anyio.to_thread.run_sync` / `run_in_threadpool`.
+- [ ] **Endpoint declaration intent** — DB-bound FastAPI endpoints/deps are sync
+      `def`, not gratuitously `async def`.
+- [ ] **Test coverage** — new async endpoints/helpers are exercised by an
+      integration test (so the aiocop guard can see them).
+
+## Output Format
+
+For each issue found, report:
+1. **File and line number**
+2. **Issue type** (from review criteria above)
+3. **Current code snippet** (the blocking call)
+4. **Recommended fix** (which recipe, and the tradeoff)
+5. **Severity** — high if it blocks the event loop on a request path; medium for
+   untested async paths; low for stylistic `async` with no blocking call.
+
+Summarize findings with counts by issue type and an overall event-loop-safety
+assessment.

--- a/generated_agentic_operations/commands/frameworks-review-async-sync.md
+++ b/generated_agentic_operations/commands/frameworks-review-async-sync.md
@@ -29,7 +29,8 @@ Galaxy's database layer uses a synchronous `sqlalchemy.orm.Session`, so
 blocking calls. Doing any of them from an `async def` without offloading is an
 event-loop hazard.
 
-Real example surfaced in review of `galaxyproject/galaxy#22361`:
+Canonical anti-pattern — declared `async`, but the body only does blocking
+sync `Session` work:
 
 ```python
 # ANTI-PATTERN: async, but session is a sync Session — this blocks the loop
@@ -42,7 +43,7 @@ async def list_history_items(session: Session, history_id: int) -> str:
     ...
 ```
 
-Reviewer verdict: *"This is a must before merging, this would block the event loop."*
+This blocks the event loop and must be fixed, not merged.
 
 ## Review Criteria
 
@@ -101,14 +102,18 @@ genuinely async. Rare in Galaxy; do not introduce it casually.
 Galaxy ships an `aiocop` integration
 (`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
 `GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
-catch blocking syscalls from inside async tasks and surfaces them on an
-`X-Aiocop-Violations` response header so the harness can fail offending requests
-(see `test/integration/test_event_loop_blocking.py`).
+catch specific blocking syscalls (`socket.connect`, `open`, `subprocess.Popen`,
+…) from inside async tasks and surfaces per-request violations on an
+`X-Aiocop-Violations` header; the API test interactor fails any request whose
+severity reaches aiocop's high threshold (see
+`test/integration/test_event_loop_blocking.py` and
+`galaxy_test.base.api._check_aiocop_violations`).
 
-The guard only fires on code paths actually exercised under tests with aiocop
-enabled. An `async def` helper with no integration coverage slips straight
-through. Therefore: review the declaration intent directly — do not assume the
-guard will catch it — and check that new async code has tests that run it.
+It is a *runtime* audit hook, not a static check — it only fires on code paths
+actually executed under the suite with aiocop enabled. An `async def` with no
+integration coverage (or a sub-threshold blocking call) slips straight through.
+Therefore: review the declaration intent directly — do not assume the guard
+will catch it — and check that new async code has tests that run it.
 
 ## Related Code Paths
 

--- a/images/event_loop_blocking.mermaid.txt
+++ b/images/event_loop_blocking.mermaid.txt
@@ -1,0 +1,27 @@
+%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '14px' }}}%%
+flowchart LR
+    subgraph BAD["❌ async def with blocking I/O"]
+        direction TB
+        BA[Request A] --> BEL((Event Loop))
+        BB[Request B] -. waiting .-> BEL
+        BC[Request C] -. waiting .-> BEL
+        BEL --> BH["blocking I/O<br/>freezes the loop"]
+    end
+
+    subgraph GOOD["✅ sync def → threadpool"]
+        direction TB
+        GA[Request A] --> GEL((Event Loop))
+        GB[Request B] --> GEL
+        GC[Request C] --> GEL
+        GEL --> GW1[Thread 1]
+        GEL --> GW2[Thread 2]
+        GEL --> GW3[Thread 3]
+    end
+
+    classDef blocked fill:#ffcdd2,stroke:#b71c1c
+    classDef ok fill:#c8e6c9,stroke:#2e7d32
+    classDef loop fill:#e1f5fe,stroke:#01579b
+
+    class BH blocked
+    class GW1,GW2,GW3 ok
+    class BEL,GEL loop

--- a/review/generated_commands.yaml
+++ b/review/generated_commands.yaml
@@ -12,4 +12,7 @@ commands:
   - source: client-review-ui-components.md
     target: gx-review-ui-components.md
 
+  - source: frameworks-review-async-sync.md
+    target: gx-review-async-sync.md
+
 

--- a/review/generated_commands.yaml
+++ b/review/generated_commands.yaml
@@ -15,4 +15,3 @@ commands:
   - source: frameworks-review-async-sync.md
     target: gx-review-async-sync.md
 
-

--- a/review/generated_commands/gx-review-async-sync.md
+++ b/review/generated_commands/gx-review-async-sync.md
@@ -1,0 +1,147 @@
+# Review Galaxy Code for Async/Sync Event-Loop Safety
+
+Perform a Python code review on the provided Galaxy code. Accept input in any of the following forms:
+1. A working directory path (analyze git diff in that directory)
+2. A Git commit reference (analyze changes in that commit)
+3. A PR reference (analyze changes in that pull request)
+4. A list of Python file paths (analyze those files)
+5. A planning document (analyze the Python files in the plan)
+
+## Who You Are
+
+- You are an expert in Python asyncio and ASGI (Starlette / FastAPI / uvicorn).
+- You know Galaxy serves FastAPI on a single ASGI event loop, and that Galaxy's
+  SQLAlchemy `Session` is **synchronous**.
+- You are a senior engineer who cares that one slow request must not stall every
+  other concurrent user on a worker.
+
+## Why This Matters
+
+Galaxy serves FastAPI on a single ASGI event loop (uvicorn). A function declared
+`async def` runs *on* that loop; a synchronous `def` endpoint/dependency is run
+by Starlette in a threadpool instead. A blocking call inside an `async def`
+therefore freezes the entire event loop — stalling **every** concurrent request
+on that worker, not just the caller.
+
+Galaxy's database layer uses a synchronous `sqlalchemy.orm.Session`, so
+`session.execute(...)`, `session.scalars(...)`, `.all()`,
+`.scalar_one_or_none()`, and lazy ORM attribute/relationship access are all
+blocking calls. Doing any of them from an `async def` without offloading is an
+event-loop hazard.
+
+Real example surfaced in review of `galaxyproject/galaxy#22361`:
+
+```python
+# ANTI-PATTERN: async, but session is a sync Session — this blocks the loop
+async def list_history_items(session: Session, history_id: int) -> str:
+    hda_rows = session.execute(
+        select(HDA.id, HDA.hid, HDA.name)
+        .join(Dataset, HDA.dataset_id == Dataset.id)
+        .where(HDA.history_id == history_id)
+    ).all()
+    ...
+```
+
+Reviewer verdict: *"This is a must before merging, this would block the event loop."*
+
+## Review Criteria
+
+Flag and recommend fixes for:
+
+1. **`async def` doing sync DB work** — sync `Session` queries (`execute`,
+   `scalars`, `.all()`, `.scalar_one_or_none()`), or lazy ORM
+   attribute/relationship access that triggers a query, inside a coroutine.
+2. **`async def` calling blocking managers/services** — invoking Galaxy
+   managers/services that do sync DB or filesystem I/O without
+   `anyio.to_thread.run_sync` / `run_in_threadpool`.
+3. **`async def` doing blocking filesystem/subprocess/HTTP** — `open(...)`,
+   `os.stat`, `shutil`, `subprocess.run`, `requests`/`urllib` instead of async
+   equivalents.
+4. **`async def` that never `await`s** — a strong signal it should be `def`.
+5. **Untested async paths** — new `async def` endpoints/helpers with no
+   integration test exercising them under `GALAXY_TEST_AIOCOP`. The guard cannot
+   catch code paths that tests never run.
+
+## Decision Tree
+
+- Does the function perform genuine async I/O (httpx, websockets, anyio,
+  `AsyncSession`)? → `async def` is appropriate.
+- Does it touch the sync `Session` or other blocking I/O and run as a FastAPI
+  endpoint/dependency? → make it plain `def`; FastAPI runs it in a threadpool.
+- Must blocking code be invoked from an existing `async def`? → offload it:
+  `await anyio.to_thread.run_sync(partial(fn, *args))`.
+
+## Fix Recipes
+
+**Preferred — drop `async`, let FastAPI's threadpool handle it** (best for
+DB-bound work; matches existing sync `def` controllers, e.g.
+`lib/galaxy/webapps/galaxy/controllers/api/roles.py`):
+
+```diff
+-async def list_history_items(session: Session, history_id: int) -> str:
++def list_history_items(session: Session, history_id: int) -> str:
+     rows = session.execute(select(...)).all()
+```
+
+**Offload at the call site** when the caller must stay `async` (pattern already
+used in `lib/galaxy/webapps/galaxy/api/chat.py`):
+
+```python
+from functools import partial
+import anyio
+
+rows = await anyio.to_thread.run_sync(partial(list_history_items, session, history_id))
+```
+
+**True async adapter / `AsyncSession`** — only when the surrounding stack is
+genuinely async. Rare in Galaxy; do not introduce it casually.
+
+## The aiocop Guard (and Its Limit)
+
+Galaxy ships an `aiocop` integration
+(`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
+`GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
+catch blocking syscalls from inside async tasks and surfaces them on an
+`X-Aiocop-Violations` response header so the harness can fail offending requests
+(see `test/integration/test_event_loop_blocking.py`).
+
+The guard only fires on code paths actually exercised under tests with aiocop
+enabled. An `async def` helper with no integration coverage slips straight
+through. Therefore: review the declaration intent directly — do not assume the
+guard will catch it — and check that new async code has tests that run it.
+
+## Related Code Paths
+
+- `lib/galaxy/web/framework/middleware/aiocop_integration.py` — the guard.
+- `test/integration/test_event_loop_blocking.py` — how the guard is exercised.
+- `lib/galaxy/webapps/galaxy/api/chat.py` — correct `anyio.to_thread.run_sync` usage.
+- `lib/galaxy/webapps/galaxy/controllers/api/roles.py` — sync `def` controllers (the norm).
+
+## Review Checklist
+
+For each file/change, check:
+
+- [ ] **No sync DB in coroutines** — `async def` bodies don't call sync
+      `Session` queries or trigger lazy ORM loads.
+- [ ] **No blocking I/O in coroutines** — no `open`/`os`/`shutil`/`subprocess`/
+      `requests` in `async def` without offload.
+- [ ] **`async` is justified** — every `async def` actually `await`s real async I/O.
+- [ ] **Offload used correctly** — blocking calls from `async` use
+      `anyio.to_thread.run_sync` / `run_in_threadpool`.
+- [ ] **Endpoint declaration intent** — DB-bound FastAPI endpoints/deps are sync
+      `def`, not gratuitously `async def`.
+- [ ] **Test coverage** — new async endpoints/helpers are exercised by an
+      integration test (so the aiocop guard can see them).
+
+## Output Format
+
+For each issue found, report:
+1. **File and line number**
+2. **Issue type** (from review criteria above)
+3. **Current code snippet** (the blocking call)
+4. **Recommended fix** (which recipe, and the tradeoff)
+5. **Severity** — high if it blocks the event loop on a request path; medium for
+   untested async paths; low for stylistic `async` with no blocking call.
+
+Summarize findings with counts by issue type and an overall event-loop-safety
+assessment.

--- a/review/generated_commands/gx-review-async-sync.md
+++ b/review/generated_commands/gx-review-async-sync.md
@@ -29,7 +29,8 @@ Galaxy's database layer uses a synchronous `sqlalchemy.orm.Session`, so
 blocking calls. Doing any of them from an `async def` without offloading is an
 event-loop hazard.
 
-Real example surfaced in review of `galaxyproject/galaxy#22361`:
+Canonical anti-pattern — declared `async`, but the body only does blocking
+sync `Session` work:
 
 ```python
 # ANTI-PATTERN: async, but session is a sync Session — this blocks the loop
@@ -42,7 +43,7 @@ async def list_history_items(session: Session, history_id: int) -> str:
     ...
 ```
 
-Reviewer verdict: *"This is a must before merging, this would block the event loop."*
+This blocks the event loop and must be fixed, not merged.
 
 ## Review Criteria
 
@@ -101,14 +102,18 @@ genuinely async. Rare in Galaxy; do not introduce it casually.
 Galaxy ships an `aiocop` integration
 (`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
 `GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
-catch blocking syscalls from inside async tasks and surfaces them on an
-`X-Aiocop-Violations` response header so the harness can fail offending requests
-(see `test/integration/test_event_loop_blocking.py`).
+catch specific blocking syscalls (`socket.connect`, `open`, `subprocess.Popen`,
+…) from inside async tasks and surfaces per-request violations on an
+`X-Aiocop-Violations` header; the API test interactor fails any request whose
+severity reaches aiocop's high threshold (see
+`test/integration/test_event_loop_blocking.py` and
+`galaxy_test.base.api._check_aiocop_violations`).
 
-The guard only fires on code paths actually exercised under tests with aiocop
-enabled. An `async def` helper with no integration coverage slips straight
-through. Therefore: review the declaration intent directly — do not assume the
-guard will catch it — and check that new async code has tests that run it.
+It is a *runtime* audit hook, not a static check — it only fires on code paths
+actually executed under the suite with aiocop enabled. An `async def` with no
+integration coverage (or a sub-threshold blocking call) slips straight through.
+Therefore: review the declaration intent directly — do not assume the guard
+will catch it — and check that new async code has tests that run it.
 
 ## Related Code Paths
 

--- a/topics/frameworks/content.yaml
+++ b/topics/frameworks/content.yaml
@@ -561,17 +561,19 @@
     `session.execute(...)` is a blocking call.
   class: reduce70
 - type: slide
+  id: event-loop-blocking-diagram
+  class: center
+  content: '![Event Loop Blocking vs Threadpool](../../images/event_loop_blocking.mermaid.svg)'
+- type: slide
   id: why-event-loop-blocking
   heading: Why This Breaks Galaxy
   content: |-
-    - Galaxy serves FastAPI on a single ASGI event loop (uvicorn).
-    - `async def` runs *on* the loop; sync `def` runs in a threadpool.
-    - A blocking call inside `async def` freezes the loop — stalling *every*
-      concurrent request on that worker, not just the caller.
-    - Galaxy's `Session` is synchronous, so `session.execute(...)` blocks.
+    - One ASGI event loop per worker; `async def` runs *on* it.
+    - A blocking call inside `async def` stalls *every* concurrent request — not just the caller.
+    - Sync `def` is dispatched to a threadpool, leaving the loop free.
 
     > A blocking call in an `async def` is an event-loop hazard — fix it, don't merge it.
-  class: enlarge120
+  class: enlarge150
 - type: slide
   id: galaxy-async-sync-convention
   heading: 'Convention: Default to Sync `def`'
@@ -591,34 +593,45 @@
     rows = await anyio.to_thread.run_sync(partial(list_history_items, session, history_id))
     ```
   class: reduce90
-- type: prose
-  id: aiocop-guard-only-catches-tested-code
-  heading: The Guard Only Catches Tested Code
+- type: slide
+  id: aiocop-guard
+  heading: The aiocop Guard
   content: |-
-    Galaxy ships an `aiocop` integration
-    (`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
-    `GALAXY_TEST_AIOCOP` environment variable). aiocop installs `sys.audit`
-    hooks that catch specific blocking syscalls — `socket.connect`, `open`,
-    `subprocess.Popen`, and similar — when they run inside an async task, and
-    records the offending call site. Galaxy wraps this in an ASGI middleware
-    that attaches any per-request violations to an `X-Aiocop-Violations`
-    response header (`count=…;severity=…;first=…`); the API test interactor
-    fails any request whose maximum severity reaches aiocop's high threshold
-    (see `test/integration/test_event_loop_blocking.py` and
-    `galaxy_test.base.api._check_aiocop_violations`). It is a test-only
-    dependency — not imported by production servers.
+    Opt-in via `GALAXY_TEST_AIOCOP=1` — `sys.audit` hooks catch blocking
+    syscalls inside async tasks and tag the response with
+    `X-Aiocop-Violations`; the test interactor fails any high-severity hit.
+
+    - Runtime audit hook, **not** a static check.
+    - Only sees code paths a test actually executes.
+    - Untested `async def` slips through — declaration intent is on review.
+
+    `lib/galaxy/web/framework/middleware/aiocop_integration.py` ·
+    `test/integration/test_event_loop_blocking.py`
+  class: enlarge120
+- type: prose
+  id: aiocop-guard-explanation
+  content: |-
+    Galaxy's `aiocop` integration
+    (`lib/galaxy/web/framework/middleware/aiocop_integration.py`) installs
+    `sys.audit` hooks that catch specific blocking syscalls — `socket.connect`,
+    `open`, `subprocess.Popen`, and similar — when they run inside an async
+    task, and records the offending call site. Galaxy wraps this in an ASGI
+    middleware that attaches any per-request violations to an
+    `X-Aiocop-Violations` response header
+    (`count=…;severity=…;first=…`); the API test interactor
+    (`galaxy_test.base.api._check_aiocop_violations`) fails any request whose
+    maximum severity reaches aiocop's high threshold. It is a test-only
+    dependency, opt-in via `GALAXY_TEST_AIOCOP`, and is not imported by
+    production servers.
 
     The limitation that matters: aiocop is a *runtime* audit hook, not a static
     check. It only observes a blocking call on a code path that is actually
-    executed while aiocop is active — i.e. under the integration suite with
-    `GALAXY_TEST_AIOCOP` set. An `async def` that does synchronous I/O but is
-    never exercised by such a test slips straight through; so does one whose
-    blocking call stays below the severity threshold. The guard is a safety net
-    for covered paths, not a substitute for getting the declaration right.
-    Treat sync-vs-async correctness as a code-review responsibility — check
-    whether a coroutine genuinely awaits async I/O — and give new async
-    endpoints and helpers integration coverage that runs them so the guard can
-    see them.
+    executed while aiocop is active. An `async def` that does synchronous I/O
+    but is never exercised by such a test slips straight through; so does one
+    whose blocking call stays below the severity threshold. The guard is a
+    safety net for covered paths, not a substitute for getting the declaration
+    right — treat sync-vs-async correctness as a code-review responsibility and
+    give new async endpoints integration coverage that runs them.
 - type: agent-context
   id: async-sync-review-red-flags
   heading: Async/Sync Review Red Flags

--- a/topics/frameworks/content.yaml
+++ b/topics/frameworks/content.yaml
@@ -571,8 +571,6 @@
     - One ASGI event loop per worker; `async def` runs *on* it.
     - A blocking call inside `async def` stalls *every* concurrent request — not just the caller.
     - Sync `def` is dispatched to a threadpool, leaving the loop free.
-
-    > A blocking call in an `async def` is an event-loop hazard — fix it, don't merge it.
   class: enlarge150
 - type: slide
   id: galaxy-async-sync-convention

--- a/topics/frameworks/content.yaml
+++ b/topics/frameworks/content.yaml
@@ -542,6 +542,124 @@
     ```
   class: reduce70
 - type: slide
+  id: async-def-blocking-pitfall
+  heading: 'Pitfall: `async def` Doing Blocking I/O'
+  content: |-
+    Spotted in review of `galaxyproject/galaxy#22361`:
+
+    ```python
+    async def list_history_items(session: Session, history_id: int) -> str:
+        hda_rows = session.execute(
+            select(HDA.id, HDA.hid, HDA.name)
+            .join(Dataset, HDA.dataset_id == Dataset.id)
+            .where(HDA.history_id == history_id)
+        ).all()
+        ...
+    ```
+
+    Declared `async`, but `session` is a **synchronous** SQLAlchemy `Session` —
+    `session.execute(...)` is a blocking call.
+  class: reduce70
+- type: slide
+  id: why-event-loop-blocking
+  heading: Why This Breaks Galaxy
+  content: |-
+    - Galaxy serves FastAPI on a single ASGI event loop (uvicorn).
+    - `async def` runs *on* the loop; sync `def` runs in a threadpool.
+    - A blocking call inside `async def` freezes the loop — stalling *every*
+      concurrent request on that worker, not just the caller.
+    - Galaxy's `Session` is synchronous, so `session.execute(...)` blocks.
+
+    > "This is a must before merging, this would block the event loop."
+    > — review of `galaxyproject/galaxy#22361`
+  class: enlarge120
+- type: slide
+  id: galaxy-async-sync-convention
+  heading: 'Convention: Default to Sync `def`'
+  content: |-
+    ```diff
+    -async def list_history_items(session: Session, history_id: int) -> str:
+    +def list_history_items(session: Session, history_id: int) -> str:
+         rows = session.execute(select(...)).all()
+    ```
+
+    - DB-bound service/handler code: plain `def` — FastAPI runs it in a threadpool.
+    - Use `async def` *only* for genuine async I/O (httpx, websockets, anyio).
+    - Must call blocking code from `async`? Offload it:
+
+    ```python
+    rows = await anyio.to_thread.run_sync(partial(list_history_items, session, history_id))
+    ```
+  class: reduce90
+- type: prose
+  id: aiocop-guard-only-catches-tested-code
+  heading: The Guard Only Catches Tested Code
+  content: |-
+    Galaxy ships an `aiocop` integration
+    (`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
+    `GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
+    catch blocking syscalls made from inside async tasks. Violations are surfaced
+    on an `X-Aiocop-Violations` response header so the test harness can fail
+    requests that block the event loop (see
+    `test/integration/test_event_loop_blocking.py`).
+
+    The reviewer's question on `galaxyproject/galaxy#22361` — *"Our aiocop
+    integration should have flagged this, is this executed in our test suite?"* —
+    is the real lesson. The audit hook only fires on code paths actually
+    exercised under tests with aiocop enabled. An `async def` helper with no
+    integration coverage slips straight through the guard. So new async
+    endpoints and helpers need test coverage that exercises them, and code
+    review must check the declaration intent directly — whether a coroutine
+    genuinely does async I/O — rather than trusting the guard to catch it.
+- type: agent-context
+  id: async-sync-review-red-flags
+  heading: Async/Sync Review Red Flags
+  content: |-
+    When reviewing Galaxy Python changes for event-loop safety:
+
+    **Red flags**
+
+    1. `async def` whose body does synchronous DB work — `session.execute(...)`,
+       `session.scalars(...)`, `.all()`, `.scalar_one_or_none()`, lazy ORM
+       attribute/relationship access that triggers a query — on a synchronous
+       `sqlalchemy.orm.Session`.
+    2. `async def` calling blocking Galaxy managers/services that themselves do
+       sync DB or filesystem I/O, without `anyio.to_thread.run_sync` /
+       `run_in_threadpool`.
+    3. `async def` doing blocking filesystem or subprocess work (`open(...)`,
+       `os.stat`, `shutil`, `subprocess.run`, `requests`/`urllib`) instead of
+       async equivalents.
+    4. A coroutine declared `async` that never `await`s anything — a strong
+       signal it should just be `def`.
+    5. New `async def` endpoints/helpers with no integration test that exercises
+       them under `GALAXY_TEST_AIOCOP` (the guard cannot catch untested paths).
+
+    **Decision tree**
+
+    - Does the function perform real async I/O (httpx, websockets, anyio,
+      `AsyncSession`)? → `async def` is appropriate.
+    - Does it touch the sync `Session` or other blocking I/O and is it called
+      as a FastAPI endpoint/dependency? → make it plain `def`; FastAPI runs it
+      in a threadpool.
+    - Must blocking code be invoked from an existing `async def`? → wrap it:
+      `await anyio.to_thread.run_sync(partial(fn, *args))`.
+
+    **Fix recipes**
+
+    - Drop the `async` keyword and let FastAPI's threadpool handle it (preferred
+      for DB-bound work; matches existing sync `def` controllers like
+      `lib/galaxy/webapps/galaxy/controllers/api/roles.py`).
+    - Offload at the call site with `anyio.to_thread.run_sync` (pattern already
+      used in `lib/galaxy/webapps/galaxy/api/chat.py`).
+    - Only convert to a true async DB adapter / `AsyncSession` when the
+      surrounding stack is genuinely async (rare in Galaxy).
+
+    **Reference paths**
+
+    - `lib/galaxy/web/framework/middleware/aiocop_integration.py` — the guard.
+    - `test/integration/test_event_loop_blocking.py` — how it is exercised.
+    - `lib/galaxy/webapps/galaxy/api/chat.py` — correct `anyio.to_thread.run_sync` usage.
+- type: slide
   id: fastapi-and-pydantic
   heading: FastAPI and Pydantic
   content: |-

--- a/topics/frameworks/content.yaml
+++ b/topics/frameworks/content.yaml
@@ -605,6 +605,8 @@
 
     `lib/galaxy/web/framework/middleware/aiocop_integration.py` ·
     `test/integration/test_event_loop_blocking.py`
+
+    https://github.com/galaxyproject/galaxy/pull/22207
   class: enlarge120
 - type: prose
   id: aiocop-guard-explanation

--- a/topics/frameworks/content.yaml
+++ b/topics/frameworks/content.yaml
@@ -545,7 +545,7 @@
   id: async-def-blocking-pitfall
   heading: 'Pitfall: `async def` Doing Blocking I/O'
   content: |-
-    Spotted in review of `galaxyproject/galaxy#22361`:
+    A common mistake — a helper declared `async` that only does blocking work:
 
     ```python
     async def list_history_items(session: Session, history_id: int) -> str:
@@ -570,8 +570,7 @@
       concurrent request on that worker, not just the caller.
     - Galaxy's `Session` is synchronous, so `session.execute(...)` blocks.
 
-    > "This is a must before merging, this would block the event loop."
-    > — review of `galaxyproject/galaxy#22361`
+    > A blocking call in an `async def` is an event-loop hazard — fix it, don't merge it.
   class: enlarge120
 - type: slide
   id: galaxy-async-sync-convention
@@ -597,20 +596,28 @@
   content: |-
     Galaxy ships an `aiocop` integration
     (`lib/galaxy/web/framework/middleware/aiocop_integration.py`, opt-in via the
-    `GALAXY_TEST_AIOCOP` environment variable) that installs `sys.audit` hooks to
-    catch blocking syscalls made from inside async tasks. Violations are surfaced
-    on an `X-Aiocop-Violations` response header so the test harness can fail
-    requests that block the event loop (see
-    `test/integration/test_event_loop_blocking.py`).
+    `GALAXY_TEST_AIOCOP` environment variable). aiocop installs `sys.audit`
+    hooks that catch specific blocking syscalls — `socket.connect`, `open`,
+    `subprocess.Popen`, and similar — when they run inside an async task, and
+    records the offending call site. Galaxy wraps this in an ASGI middleware
+    that attaches any per-request violations to an `X-Aiocop-Violations`
+    response header (`count=…;severity=…;first=…`); the API test interactor
+    fails any request whose maximum severity reaches aiocop's high threshold
+    (see `test/integration/test_event_loop_blocking.py` and
+    `galaxy_test.base.api._check_aiocop_violations`). It is a test-only
+    dependency — not imported by production servers.
 
-    The reviewer's question on `galaxyproject/galaxy#22361` — *"Our aiocop
-    integration should have flagged this, is this executed in our test suite?"* —
-    is the real lesson. The audit hook only fires on code paths actually
-    exercised under tests with aiocop enabled. An `async def` helper with no
-    integration coverage slips straight through the guard. So new async
-    endpoints and helpers need test coverage that exercises them, and code
-    review must check the declaration intent directly — whether a coroutine
-    genuinely does async I/O — rather than trusting the guard to catch it.
+    The limitation that matters: aiocop is a *runtime* audit hook, not a static
+    check. It only observes a blocking call on a code path that is actually
+    executed while aiocop is active — i.e. under the integration suite with
+    `GALAXY_TEST_AIOCOP` set. An `async def` that does synchronous I/O but is
+    never exercised by such a test slips straight through; so does one whose
+    blocking call stays below the severity threshold. The guard is a safety net
+    for covered paths, not a substitute for getting the declaration right.
+    Treat sync-vs-async correctness as a code-review responsibility — check
+    whether a coroutine genuinely awaits async I/O — and give new async
+    endpoints and helpers integration coverage that runs them so the guard can
+    see them.
 - type: agent-context
   id: async-sync-review-red-flags
   heading: Async/Sync Review Red Flags

--- a/topics/frameworks/content.yaml
+++ b/topics/frameworks/content.yaml
@@ -584,6 +584,7 @@
 
     - DB-bound service/handler code: plain `def` — FastAPI runs it in a threadpool.
     - Use `async def` *only* for genuine async I/O (httpx, websockets, anyio).
+    - Exercise every new async path with an API/integration test — untested async I/O is unverified.
     - Must call blocking code from `async`? Offload it:
 
     ```python

--- a/topics/frameworks/metadata.yaml
+++ b/topics/frameworks/metadata.yaml
@@ -20,6 +20,7 @@ training:
   - Routing maps URLs to controllers
   - 'Three types of controllers: FastAPI, WSGI API, legacy web'
   - '`async def` must not do blocking sync I/O — default to sync `def`'
+  - Exercise new async code paths with API/integration tests — untested async I/O is unverified
   time_estimation: 25m
   previous_to: files
   continues_to: dependency-injection

--- a/topics/frameworks/metadata.yaml
+++ b/topics/frameworks/metadata.yaml
@@ -38,8 +38,8 @@ related_code_paths:
   - path: lib/galaxy/webapps/galaxy/api/chat.py
     note: Correct anyio.to_thread.run_sync offload pattern from async endpoints
 related_pull_requests:
-  - pull_request: galaxyproject/galaxy#22361
-    note: Review that surfaced async-declared helpers doing blocking sync DB I/O
+- note: Review surfaced async-declared helpers doing blocking sync DB I/O
+  pull_request: https://github.com/galaxyproject/galaxy/pull/22361
 agentic_operations:
   - name: review-async-sync
     prompt: |

--- a/topics/frameworks/metadata.yaml
+++ b/topics/frameworks/metadata.yaml
@@ -12,12 +12,14 @@ training:
   - Learn about ASGI, Starlette, and FastAPI
   - Understand WSGI and legacy routing
   - Learn about middleware layers
+  - Avoid blocking the ASGI event loop from async handlers
   key_points:
   - FastAPI (ASGI) for new API endpoints
   - WSGI for legacy endpoints
   - Middleware handles cross-cutting concerns
   - Routing maps URLs to controllers
   - 'Three types of controllers: FastAPI, WSGI API, legacy web'
+  - '`async def` must not do blocking sync I/O — default to sync `def`'
   time_estimation: 25m
   previous_to: files
   continues_to: dependency-injection
@@ -27,4 +29,48 @@ sphinx:
 contributors:
   - jmchilton
 related_topics: []
-related_code_paths: []
+related_code_paths:
+  - path: lib/galaxy/web/framework/middleware/aiocop_integration.py
+    note: aiocop integration that audits blocking syscalls in async tasks
+  - path: test/integration/test_event_loop_blocking.py
+    note: Integration test exercising the aiocop blocking-I/O guard
+  - path: lib/galaxy/webapps/galaxy/api/chat.py
+    note: Correct anyio.to_thread.run_sync offload pattern from async endpoints
+related_pull_requests:
+  - pull_request: galaxyproject/galaxy#22361
+    note: Review that surfaced async-declared helpers doing blocking sync DB I/O
+agentic_operations:
+  - name: review-async-sync
+    prompt: |
+      Perform a Python code review on the provided Galaxy code. Accept input in any of the following forms:
+      1. A working directory path (analyze git diff in that directory)
+      2. A Git commit reference (analyze changes in that commit)
+      3. A PR reference (analyze changes in that pull request)
+      4. A list of Python file paths (analyze those files)
+      5. A planning document (analyze the Python files in the plan)
+
+      ## Who you are
+
+      - You are an expert in Python asyncio and ASGI (Starlette/FastAPI/uvicorn).
+      - You understand that Galaxy serves FastAPI on a single event loop and that
+        Galaxy's SQLAlchemy `Session` is synchronous.
+      - You are a senior engineer who cares about not stalling concurrent
+        requests for every user on a worker.
+
+      ## What to do
+
+      - Review the Async/Sync Review Red Flags best practices below.
+      - Flag every `async def` (endpoint, dependency, manager/service helper)
+        whose body performs blocking synchronous I/O — sync `Session` queries,
+        lazy ORM attribute/relationship access, filesystem, subprocess, or
+        blocking HTTP — without offloading via `anyio.to_thread.run_sync` /
+        `run_in_threadpool`.
+      - For each finding, recommend the concrete fix: drop `async` (let FastAPI
+        use its threadpool), offload the blocking call, or move to a true async
+        adapter — and explain the tradeoff.
+      - Flag `async def` functions that never `await` anything.
+      - Check whether new async endpoints/helpers have integration test coverage
+        that would exercise them under the aiocop guard; note that the guard
+        cannot catch untested paths.
+      - Be concrete: cite file:line, the blocking call, and the recommended fix.
+    type: claude-slash-command

--- a/topics/frameworks/metadata.yaml
+++ b/topics/frameworks/metadata.yaml
@@ -38,6 +38,8 @@ related_code_paths:
   - path: lib/galaxy/webapps/galaxy/api/chat.py
     note: Correct anyio.to_thread.run_sync offload pattern from async endpoints
 related_pull_requests:
+- note: Introduced the aiocop event-loop blocking-I/O guard
+  pull_request: https://github.com/galaxyproject/galaxy/pull/22207
 - note: Review surfaced async-declared helpers doing blocking sync DB I/O
   pull_request: https://github.com/galaxyproject/galaxy/pull/22361
 agentic_operations:

--- a/topics/frameworks/suggestions/review-async-sync.md
+++ b/topics/frameworks/suggestions/review-async-sync.md
@@ -1,36 +1,77 @@
-# Content Suggestions: review-async-sync
+# Improvement Suggestions for `review-async-sync` Operation
 
-Ideas to make the generated `review-async-sync` command more effective by
-enriching `topics/frameworks/content.yaml`.
+Suggestions for enhancing `topics/frameworks/content.yaml` to make the
+`review-async-sync` code review operation more effective.
 
-## Strong additions
+## Content Gaps Identified
 
-- **A worked "good" controller slide** showing a sync `def` endpoint that calls
-  a manager doing DB work, side by side with the offload variant. The command
-  currently describes the fixes; a canonical positive example from Galaxy would
-  let the reviewer pattern-match instead of reason from rules.
-- **Lazy-load trap example** — a slide showing an `async def` that returns fast
-  but triggers a blocking query via lazy relationship access
-  (`hdca.collection.elements`). This is the subtlest red flag and deserves its
-  own concrete example; it overlaps with the PR #22361 memory comments.
-- **aiocop output sample** — show an actual `X-Aiocop-Violations` header / log
-  line so the command can teach the agent to recognize guard output in test
-  logs and CI, not just reason about source.
+### 1. Missing: Canonical "good" controller example
 
-## Medium additions
+**Problem:** Current async/sync content shows the anti-pattern and the fix
+diff, but no end-to-end positive example. The generated command had to
+synthesize the good path from references to `roles.py` and `chat.py`
+rather than from topic content.
 
-- **WSGI vs ASGI contrast** — a note that legacy WSGI controllers do not have
-  this hazard (each request is its own thread), so the rule is specific to the
-  FastAPI/ASGI path. Prevents false positives on legacy code.
-- **`run_in_threadpool` vs `anyio.to_thread.run_sync`** — a one-line note on
-  when each is idiomatic in Galaxy, so recommendations are consistent.
+**Suggestion:** Add a slide pairing a sync `def` endpoint with the manager
+it calls (DB-bound), and a second showing the same flow with an
+`anyio.to_thread.run_sync` offload when the caller must stay `async`.
+Reviewers can then pattern-match instead of reasoning from rules.
 
-## Content gaps observed while generating
+### 2. Missing: Lazy ORM load trap
 
-- `content.yaml` has no positive/"good" full example for this section — only the
-  anti-pattern and the diff. The command had to synthesize the good path from
-  `roles.py` and `chat.py` references rather than from topic content.
-- No coverage of how to *test* an async path under aiocop locally (the env var
-  and the integration test exist but the invocation recipe is not in content).
-  A short prose block with the local repro command would let the command give
-  actionable test guidance.
+**Problem:** The subtlest red flag is an `async def` that returns fast but
+triggers a blocking query via lazy relationship access
+(`hdca.collection.elements`, attribute autoloads). This kind of block
+doesn't look like a query in the source.
+
+**Suggestion:** A dedicated slide showing a lazy-load chain inside `async
+def` and the diff to either eager-load (`selectinload`) or sync-ify the
+helper. Worth its own block because it's not visible by grep.
+
+### 3. Missing: WSGI-vs-ASGI scope clarification
+
+**Problem:** The rule "default to sync `def`" is specific to the ASGI/
+FastAPI path. Legacy WSGI controllers do not have this hazard — each
+request is its own thread. Without this scope statement the review command
+risks false positives on legacy code.
+
+**Suggestion:** Short prose block (or bullet on the convention slide)
+stating that the rule applies to FastAPI/ASGI handlers and async tasks;
+WSGI controllers are unaffected.
+
+### 4. Missing: aiocop output sample
+
+**Problem:** The aiocop slide and prose describe the `X-Aiocop-Violations`
+header abstractly. Reviewing CI/test output requires recognizing the actual
+log line and header format.
+
+**Suggestion:** Add a small inline sample of the log message and the
+header string so the command can teach the agent to spot guard output in
+test logs, not just reason about source.
+
+### 5. Missing: Local aiocop repro recipe
+
+**Problem:** The env var and the integration test exist but the invocation
+recipe is not in the topic content. Reviewers can't easily tell a
+contributor *how* to run their new async path under the guard locally.
+
+**Suggestion:** Short prose block with the local repro command (env var +
+`pytest` invocation) so the command can give actionable test guidance.
+
+## Specific Content Additions
+
+### Add: `run_in_threadpool` vs `anyio.to_thread.run_sync` idiom
+
+The convention slide shows `anyio.to_thread.run_sync` (matching
+`api/chat.py`). FastAPI also offers `starlette.concurrency.run_in_threadpool`.
+A one-line note on which Galaxy prefers and why would let recommendations
+stay consistent across reviewers.
+
+## Priority Ranking
+
+1. **High:** Lazy ORM load trap — subtlest red flag; deserves an explicit example.
+2. **High:** Canonical "good" controller example — command currently synthesizes from outside references.
+3. **Medium:** WSGI-vs-ASGI scope clarification — prevents false positives on legacy code.
+4. **Medium:** aiocop output sample — teaches log/header recognition in CI.
+5. **Low:** Offload-utility idiom note — small consistency win.
+6. **Low:** Local aiocop repro recipe — useful but covered elsewhere in Galaxy docs.

--- a/topics/frameworks/suggestions/review-async-sync.md
+++ b/topics/frameworks/suggestions/review-async-sync.md
@@ -1,0 +1,36 @@
+# Content Suggestions: review-async-sync
+
+Ideas to make the generated `review-async-sync` command more effective by
+enriching `topics/frameworks/content.yaml`.
+
+## Strong additions
+
+- **A worked "good" controller slide** showing a sync `def` endpoint that calls
+  a manager doing DB work, side by side with the offload variant. The command
+  currently describes the fixes; a canonical positive example from Galaxy would
+  let the reviewer pattern-match instead of reason from rules.
+- **Lazy-load trap example** — a slide showing an `async def` that returns fast
+  but triggers a blocking query via lazy relationship access
+  (`hdca.collection.elements`). This is the subtlest red flag and deserves its
+  own concrete example; it overlaps with the PR #22361 memory comments.
+- **aiocop output sample** — show an actual `X-Aiocop-Violations` header / log
+  line so the command can teach the agent to recognize guard output in test
+  logs and CI, not just reason about source.
+
+## Medium additions
+
+- **WSGI vs ASGI contrast** — a note that legacy WSGI controllers do not have
+  this hazard (each request is its own thread), so the rule is specific to the
+  FastAPI/ASGI path. Prevents false positives on legacy code.
+- **`run_in_threadpool` vs `anyio.to_thread.run_sync`** — a one-line note on
+  when each is idiomatic in Galaxy, so recommendations are consistent.
+
+## Content gaps observed while generating
+
+- `content.yaml` has no positive/"good" full example for this section — only the
+  anti-pattern and the diff. The command had to synthesize the good path from
+  `roles.py` and `chat.py` references rather than from topic content.
+- No coverage of how to *test* an async path under aiocop locally (the env var
+  and the integration test exist but the invocation recipe is not in content).
+  A short prose block with the local repro command would let the command give
+  actionable test guidance.


### PR DESCRIPTION
> ℹ️ Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Closes #19.

## Context

Issue #19 came from @mvdbeek's review of galaxyproject/galaxy#22361: helpers in `lib/galaxy/agents/history_tools.py` were declared `async def` but did blocking synchronous `Session` I/O. On Galaxy's single ASGI event loop that stalls **every** concurrent request on the worker. The `aiocop` guard didn't flag it — *"is this executed in our test suite?"* — because the new path had no coverage.

## What this does

**Documentation** (`topics/frameworks/`):
- 3 slides — `async-def-blocking-pitfall` (the real #22361 anti-pattern), `why-event-loop-blocking`, `galaxy-async-sync-convention` (default to sync `def`; `anyio.to_thread.run_sync` offload)
- docs-only prose `aiocop-guard-only-catches-tested-code` — the test-coverage lesson
- `agent-context` block of review red flags (powers the command, excluded from human output)
- metadata: new objective/key point, `related_code_paths`/`related_pull_requests`, `review-async-sync` agentic_operation

**Review command**: generated `gx-review-async-sync`, wired into the `gx-arch-review` marketplace plugin via `review/generated_commands.yaml`.

## Verification

- `make validate` passes (warnings only)
- Slides + Sphinx render all 3 slides; prose appears in docs only; agent-context excluded from both

## Scope decisions (please confirm)

- Home topic = `frameworks`
- async/sync declaration **only** — mvdbeek's adjacent perf flags (unbounded queries, `element_count` vs `len(elements)`, N+1) deliberately left out as a separate concern
- New generated command rather than extending the static `gx-fastapi-review`

## Notes

- `make build-sphinx` needs Java/PlantUML for its `images` prerequisite (not available in my env; the Sphinx markdown build itself succeeds — full HTML build untested here)
- `review/Makefile` hardcodes bare `python`; ran sync via `uv`. Possible follow-up to make it `uv`/`python3`-safe
- Generated slides/sphinx outputs are gitignored (transient); tracked `doc/source/architecture/frameworks.md` is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)